### PR TITLE
Bug - multi tab nonce problem (Returned nonce did not match)

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -255,12 +255,12 @@ module OmniAuth
       #
       # @return String
       def new_nonce
-        session['omniauth-azure-activedirectory.nonce'] ||= []
+        session['omniauth-azure-activedirectory.nonces'] ||= []
         nonce = SecureRandom.uuid
-        session['omniauth-azure-activedirectory.nonce'] << nonce
+        session['omniauth-azure-activedirectory.nonces'] << nonce
 
-        if session['omniauth-azure-activedirectory.nonce'].size > options.nonce_max_count
-          session['omniauth-azure-activedirectory.nonce'].shift
+        if session['omniauth-azure-activedirectory.nonces'].size > options.nonce_max_count
+          session['omniauth-azure-activedirectory.nonces'].shift
         end
 
         nonce
@@ -271,9 +271,9 @@ module OmniAuth
       # nonce wasn't found
       # @return String or nil
       def check_nonce(nonce)
-        return unless session['omniauth-azure-activedirectory.nonce']
+        return unless session['omniauth-azure-activedirectory.nonces']
 
-        session['omniauth-azure-activedirectory.nonce'].delete(nonce)
+        session['omniauth-azure-activedirectory.nonces'].delete(nonce)
       end
 
       ##

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rubocop', '~> 0.32'
   s.add_development_dependency 'simplecov', '~> 0.10'
-  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'webmock', '~> 2.3'
 end

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -38,7 +38,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
   let(:issuer) { 'https://sts.windows.net/bunch-of-random-chars' }
   let(:kid) { 'abc123' }
   let(:name) { 'John Smith' }
-  let(:nonce) { 'my nonce' }
+  let(:nonce) { ['my nonce'] }
   let(:session_state) { 'session state' }
   let(:auth_endpoint_host) { 'authorize.com' }
 
@@ -77,7 +77,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'iss' => 'https://sts.windows.net/bunch-of-random-chars',
       #     'name' => 'John Smith',
       #     'aud' => 'the client id',
-      #     'nonce' => 'my nonce',
+      #     'nonce' => ['my nonce'],
       #     'email' => 'jsmith@contoso.com',
       #     'given_name' => 'John',
       #     'family_name' => 'Smith' }
@@ -196,29 +196,23 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
     end
   end
 
-  describe '#read_nonce' do
-    let(:strategy) { described_class.new(app, client_id, tenant) }
+  describe '#new_nonce' do
+    let(:strategy) { described_class.new(app, client_id, tenant, nonce_max_count: 2) }
     let(:env) { { 'rack.session' => {} } }
     before(:each) { strategy.call!(env) }
-    subject { strategy.send(:read_nonce) }
 
-    context 'before a nonce is set' do
-      it { is_expected.to be nil }
-    end
+    it 'generate mutiple nonces configured by `nonce_max_count`' do
+      allow(SecureRandom).to receive(:uuid).and_return('n1')
+      expect(strategy.send(:new_nonce)).to eq('n1')
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n1']})
 
-    context 'after a nonce is set' do
-      before(:each) { @nonce = strategy.send(:new_nonce) }
-      it 'should match' do
-        expect(subject).to eq @nonce
-      end
-    end
+      allow(SecureRandom).to receive(:uuid).and_return('n2')
+      expect(strategy.send(:new_nonce)).to eq('n2')
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n1', 'n2']})
 
-    context 'twice in a row' do
-      before(:each) do
-        strategy.send(:new_nonce)
-        strategy.send(:read_nonce)
-      end
-      it { is_expected.to be nil }
+      allow(SecureRandom).to receive(:uuid).and_return('n3')
+      expect(strategy.send(:new_nonce)).to eq('n3')
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n2', 'n3']})
     end
   end
 end

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -38,7 +38,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
   let(:issuer) { 'https://sts.windows.net/bunch-of-random-chars' }
   let(:kid) { 'abc123' }
   let(:name) { 'John Smith' }
-  let(:nonce) { ['my nonce'] }
+  let(:nonces) { ['my nonce'] }
   let(:session_state) { 'session state' }
   let(:auth_endpoint_host) { 'authorize.com' }
 
@@ -52,7 +52,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
   let(:openid_config_response) { "{\"issuer\":\"#{issuer}\",\"authorization_endpoint\":\"http://#{auth_endpoint_host}\",\"jwks_uri\":\"https://login.windows.net/common/discovery/keys\"}" }
   let(:keys_response) { "{\"keys\":[{\"kid\":\"#{kid}\",\"x5c\":[\"#{x5c}\"]}]}" }
 
-  let(:env) { { 'rack.session' => { 'omniauth-azure-activedirectory.nonce' => nonce } } }
+  let(:env) { { 'rack.session' => { 'omniauth-azure-activedirectory.nonces' => nonces } } }
 
   before(:each) do
     stub_request(:get, "https://login.windows.net/#{tenant}/.well-known/openid-configuration")
@@ -77,7 +77,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'iss' => 'https://sts.windows.net/bunch-of-random-chars',
       #     'name' => 'John Smith',
       #     'aud' => 'the client id',
-      #     'nonce' => ['my nonce'],
+      #     'nonce' => 'my nonce',
       #     'email' => 'jsmith@contoso.com',
       #     'given_name' => 'John',
       #     'family_name' => 'Smith' }
@@ -204,15 +204,15 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
     it 'generate mutiple nonces configured by `nonce_max_count`' do
       allow(SecureRandom).to receive(:uuid).and_return('n1')
       expect(strategy.send(:new_nonce)).to eq('n1')
-      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n1']})
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonces'=>['n1']})
 
       allow(SecureRandom).to receive(:uuid).and_return('n2')
       expect(strategy.send(:new_nonce)).to eq('n2')
-      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n1', 'n2']})
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonces'=>['n1', 'n2']})
 
       allow(SecureRandom).to receive(:uuid).and_return('n3')
       expect(strategy.send(:new_nonce)).to eq('n3')
-      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonce'=>['n2', 'n3']})
+      expect(strategy.session).to eq({'omniauth-azure-activedirectory.nonces'=>['n2', 'n3']})
     end
   end
 end


### PR DESCRIPTION
Problem:
  1) Open tab 1 - it should redirect to AD (generates new nonce X and stores in session)
  2) Open tab 2 - it should redirect to AD (generates new nonce Y and stores/overwrites in session)
  3) In tab 1 Complete the sign-in AD -> Error (nonce X sent from AD doesn't match Y stored in session)
  4) In tab 2 Complete the sign-in AD -> Success (nonce Y sent from AD matches Y stored in session)

Solution:
  Add multiple nonce support for `#new_nonce`. The supported nonce count can be managed by `nonce_max_count` which can be set in options (default value 10).